### PR TITLE
Anonymize docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ localshop.db
 .coverage
 .cache
 /coverage.xml
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 db:
-    image: sameersbn/postgresql:9.4
+    image: postgres:9.6
     environment:
-        - DB_NAME
-        - DB_USER
-        - DB_PASS
+        - POSTGRES_DB
+        - POSTGRES_USER
+        - POSTGRES_PASSWORD
     ports:
         - "5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 db:
     image: sameersbn/postgresql:9.4
     environment:
-        - DB_NAME=localshop
-        - DB_USER=localshop
-        - DB_PASS=shopping
+        - DB_NAME
+        - DB_USER
+        - DB_PASS
     ports:
         - "5432"
     volumes:
@@ -16,9 +16,9 @@ web:
     links:
         - db:db
     environment:
-        - DJANGO_SECRET_KEY=a7d03faa0c054b3dba38b396bf3c7996
-        - DATABASE_URL=postgresql://localshop:shopping@db/localshop
-        - DJANGO_MEDIA_ROOT=/localshop/media
+        - DJANGO_SECRET_KEY
+        - DATABASE_URL
+        - DJANGO_MEDIA_ROOT
     ports:
         - "8000:8000"
     command: uwsgi --http 0.0.0.0:8000 --module localshop.wsgi --master --die-on-term
@@ -31,10 +31,10 @@ worker:
     links:
         - db:db
     environment:
-        - DJANGO_SECRET_KEY=a7d03faa0c054b3dba38b396bf3c7996
-        - DATABASE_URL=postgresql://localshop:shopping@db/localshop
-        - DJANGO_MEDIA_ROOT=/localshop/media
+        - DJANGO_SECRET_KEY
+        - DATABASE_URL
+        - DJANGO_MEDIA_ROOT
     entrypoint:
         localshop
-    command: 
+    command:
         celery worker -B -E


### PR DESCRIPTION
Greetings,

This pull request makes a couple of changes to docker-compose to make it safer to use.  The values for all environment variables have been removed from `docker-compose.yml` and they should, instead, be set in one of two ways:

- export them as environment variables in the shell that `docker-compose` is being run from
- write the values to a .env file alongside `docker-compose.yml`, which is automatically read by `docker-compose` and looks like this:

```
[berto@g6]$ cat .env
POSTGRES_DB=localshop
POSTGRES_USER=localshop
POSTGRES_PASSWORD=shopping
DJANGO_SECRET_KEY=a7d03faa0c054b3dba38b396bf3c7996
DATABASE_URL=postgresql://localshop:shopping@db/localshop
DJANGO_MEDIA_ROOT=/opt/localshop/media
```

This change makes the docker-compose file generic and allows the end-user to inject their own values without having to change the file.

Additionally, I updated postgres to the official image and verified that it works without any issue.  **Note:** the database name, username, and password environment variables have changed accordingly.